### PR TITLE
allow imports to have priority ordering

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,19 +1,31 @@
 var path = require('path');
 var fs = require('fs');
 
+function transformPaths(paths) {
+	if (Array.isArray(paths)) {
+		return paths;
+	}
+	return Object.keys(paths).map((key) => {
+		return {
+			key,
+			path: paths[key],
+		};
+	});
+}
+
 module.exports = function rollupPluginImportAlias(options) {
 	if (typeof options !== 'object') {
 		return {};
 	}
 
 	var extensions = (options.Extensions || ['js']);
-	var paths = options.Paths || {};
+	var paths = transformPaths(options.Paths || {});
 	return {
 		resolveId: function(importee, importer) {
 			var extCount = extensions.length;
-			for (var key in paths) {
-				if (importee.substring(0, key.length) === key) {
-					var directory = importee.replace(key, paths[key]);
+			for (var entry of paths) {
+				if (importee.substring(0, entry.key.length) === entry.key) {
+					var directory = importee.replace(entry.key, entry.path);
 					var ext, absolute;
 					for (var i = 0; i < extCount; i++) {
 						ext = extensions[i];


### PR DESCRIPTION
## Issue
The problem is objects loops non-deterministically.

`dist/config.js`: holds the default configuration
`dist2/config-override.js`: holds the overridden configuration

I have 2 Paths defined, but my config-override isn't being imported.
```js
{
  Paths: {
    "mybase": "./dist",
    "mybase/config": "./dist2/config-override",
  }
}
```

## solution
allow for array of import entries:
```js
{
  Paths: [
    { key: "mybase", path: "./dist" },
    { key: "mybase/config", path: "./dist2/config-override" },
  ]
}
```

To be backwards compatible, the existing object Path definition is automatically translated to the above format.