### PR TITLE
Do not append file extension if importee reference already has it

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,14 @@ module.exports = function rollupPluginImportAlias(options) {
 					var ext, absolute;
 					for (var i = 0; i < extCount; i++) {
 						ext = extensions[i];
-						absolute = directory + '.' + ext;
+						if (directory.endsWith('.' + ext))
+						{
+							absolute = directory;
+						}
+						else
+						{
+							absolute = directory + '.' + ext;
+						}
 						
 						if (fs.existsSync(absolute)) {
 							return path.normalize(absolute);


### PR DESCRIPTION
If the importee reference already has the file extension (like for ex…ample when importing .vue files), do not append the extension again or that will cause it not to match.